### PR TITLE
Fix comment typo

### DIFF
--- a/rocket-nginx.conf
+++ b/rocket-nginx.conf
@@ -66,7 +66,7 @@ if (-f "$document_root/.maintenance") {
 
 # Do not bypass if one of those cookie if found
 # wordpress_logged_in_[hash] : When a user is logged in, this cookie is created (we'd rather let WP-Rocket handle that)
-# wp-postpass_[hash] : When a protected pass requires a password, this cookie is created.
+# wp-postpass_[hash] : When a protected post requires a password, this cookie is created.
 if ($http_cookie ~* "(wordpress_logged_in_|wp\-postpass_)") {
 	set $rocket_bypass 0;
 	set $rocket_reason "Cookie";


### PR DESCRIPTION
I believe this was meant to say "post requires a password", rather than "pass requires a password". It's not much, but I noticed it and thought I could at least submit the change. =) 

Been testing and using this on another site, and the debug headers were a great idea. :+1: 