### PR TITLE
Enforce headers security

### DIFF
--- a/rocket-nginx.tmpl
+++ b/rocket-nginx.tmpl
@@ -124,6 +124,11 @@ location ~ /#!# WP_CONTENT_URI #!#/cache/wp-rocket/.*html$ {
 	add_header X-Rocket-Nginx-Reason $rocket_reason;
 	add_header X-Rocket-Nginx-File $rocket_file;
 	add_header Strict-Transport-Security "$rocket_hsts_value";
+	add_header Content-Security-Policy "default-src https: data: 'unsafe-eval' 'unsafe-inline'" always;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+
 	#!# HEADER_HTTP #!#
 	#!# HEADER_NON_GZIP #!#
 }
@@ -141,6 +146,10 @@ location ~ /#!# WP_CONTENT_URI #!#/cache/wp-rocket/.*_gzip$ {
 	add_header X-Rocket-Nginx-Reason $rocket_reason;
 	add_header X-Rocket-Nginx-File $rocket_file;
 	add_header Strict-Transport-Security "$rocket_hsts_value";
+	add_header Content-Security-Policy "default-src https: data: 'unsafe-eval' 'unsafe-inline'" always;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
 	#!# HEADER_HTTP #!#
 	#!# HEADER_GZIP #!#
 }


### PR DESCRIPTION
The following headers are useful while enforcing headers security
[X-Frame-Options](https://developer.mozilla.org/fr/docs/Web/HTTP/Headers/X-Frame-Options) should be set on SAMEORIGIN by default
[Content-Security-Policy](https://developer.mozilla.org/fr/docs/HTTP/CSP) should be set to "default-src https: data: 'unsafe-eval' 'unsafe-inline'" always" (minimum requirements)
[X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options)
[X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection)