### PR TITLE
Make regex location case-sensitive

### DIFF
--- a/rocket-nginx.tmpl
+++ b/rocket-nginx.tmpl
@@ -161,7 +161,7 @@ add_header X-Rocket-Nginx-File $rocket_file;
 ###################################################################################################
 # BROWSER CSS CACHE
 #
-location ~* \.css$ {
+location ~ \.css$ {
 	etag on;
 	gzip_vary on;
 	expires 30d;
@@ -172,7 +172,7 @@ location ~* \.css$ {
 ###################################################################################################
 # BROWSER JS CACHE
 #
-location ~* \.js$ {
+location ~ \.js$ {
 	etag on;
 	gzip_vary on;
 	expires 30d;
@@ -183,7 +183,7 @@ location ~* \.js$ {
 ###################################################################################################
 # BROWSER MEDIA CACHE
 #
-location ~* \.(#!# EXTENSION_MEDIAS #!#)$ {
+location ~ \.(#!# EXTENSION_MEDIAS #!#)$ {
 	etag on;
 	expires 30d;
 	#!# HEADER_MEDIAS #!#


### PR DESCRIPTION
Regex location is configured for case-insensitive matching. Using case-insensitive matching for incoming user requests is error-prone and should be generally avoided.

Switched to the case-sensitive regex ~ modifier instead of ~* to prevent handling of undesired requests.